### PR TITLE
Statistics plugin didn't install because of space on line 18.

### DIFF
--- a/plugins/statistics/statistics.setup.php
+++ b/plugins/statistics/statistics.setup.php
@@ -15,7 +15,7 @@ Auth_guests=R
 Lock_guests=W12345A
 Auth_members=R
 Lock_members=W12345A
-Requires_plugins=hits, whosonline
+Requires_plugins=hits,whosonline
 [END_COT_EXT]
 ==================== */
 


### PR DESCRIPTION
Space after the comma prevented the Statistics plugin from installing as it didn't detect the whosonline plugin properly.
