### PR TITLE
Fix #1161

### DIFF
--- a/modules/pfs/inc/pfs.functions.php
+++ b/modules/pfs/inc/pfs.functions.php
@@ -215,6 +215,8 @@ function cot_pfs_deleteall($userid)
 	{
 		return 0;
 	}
+	$pfs_dir_user = cot_pfs_path($userid);
+	$thumbs_dir_user = cot_pfs_thumbpath($userid);
 	$sql = $db->query("SELECT pfs_file, pfs_folderid FROM $db_pfs WHERE pfs_userid=$userid");
 
 	while($row = $sql->fetch())
@@ -483,6 +485,8 @@ function cot_pfs_upload($userid, $folderid='')
 				$fcheck = cot_file_check($u_tmp_name, $u_name, $f_extension);
 				if($fcheck == 1)
 				{
+					$pfs_dir_user = cot_pfs_path($userid);
+					$thumbs_dir_user = cot_pfs_thumbpath($userid);
 					if (!file_exists($pfs_dir_user.$npath.$u_newname))
 					{
 						$is_moved = true;

--- a/plugins/userimages/userimages.users.edit.update.php
+++ b/plugins/userimages/userimages.users.edit.update.php
@@ -19,10 +19,18 @@ defined('COT_CODE') or die('Wrong URL');
 
 require_once cot_incfile('userimages', 'plug');
 $userimages = cot_userimages_config_get();
+$ruserdelete = cot_import('ruserdelete','P','BOL');
 
 foreach($userimages as $code => $settings)
 {
 	$ruser["user_$code"] = cot_import("ruser$code",'P','TXT');
+	if($ruserdelete)
+	{
+		if(file_exists($ruser["user_$code"]))
+		{
+			@unlink($ruser["user_$code"]);
+		}
+	}
 }
 
 ?>


### PR DESCRIPTION
Avatars and photos are deleted with the user no matter what. There is no option asking and is not based on the delete PFS option with these changes. I didn't think an option was needed since it is an independent plugin and seemed reasonable. 
