### PR TITLE
Small fix for user age & birthdate display

### DIFF
--- a/system/functions.php
+++ b/system/functions.php
@@ -633,7 +633,7 @@ function cot_import_date($name, $usertimezone = true, $returnarray = false, $sou
 	if (count($date) > 0 && is_null($year) && is_null($month) && is_null($day) && is_null($hour) && is_null($minute))
 	{
 		// Datetime field is present in form but it is set to zero date (empty)
-		return 0;
+		return NULL;
 	}
 
 	if (($month && $day && $year) || ($day && $minute))


### PR DESCRIPTION
Scenario: Go to your account profile and have a birth date set other than '---' - '---' - '---'. Then set the birth date to '---' - '---' - '---'. Age and birth date will be based off 1970-01-01. You can see it here: http://www.cotonti.com/users/Xerora

This fix will solve this but accounts that have already been effected will need to change their birth date back and forth to get back to normal. Anything in the core that uses this function seems to have the proper type check or casting for this to work. 

Not sure a SQL update query is warranted in the patch for resetting people effected ( and those souls born on that date ) by this.
