### PR TITLE
Added #1090

### DIFF
--- a/lang/en/users.en.lang.php
+++ b/lang/en/users.en.lang.php
@@ -50,11 +50,11 @@ $L['aut_usernametooshort']= 'The user name must be at least 2 chars long';
  * User registration: messages
  */
 
-$L['aut_regrequest'] = "Hi %1\$s,\nYour account is currently inactive, an administrator will need to activate it before you can log in. You will receive another email when this has occured. After that you will be able to login with:\nUsername = %1\$s\nPassword = %2\$s";
+$L['aut_regrequest'] = "Hi %1\$s,\n\nYour account is currently inactive, an administrator will need to activate it before you can log in. You will receive another email when this has occured.";
 
-$L['aut_regreqnotice'] = "You are receiving this email because %1\$s requested a new account.\nThis user won\'t be able to login until you manually set the account as \'active\', here:\n%2\$s";
+$L['aut_regreqnotice'] = "You are receiving this email because %1\$s requested a new account.\nThis user won't be able to login until you manually set the account as 'active', here:\n%2\$s";
 
-$L['aut_emailreg'] = "Hi %1\$s,\nTo use your account you need to activate it with this link:\n%3\$s\nThen you\'ll be able to login with:\nUsername = %1\$s\nPassword = %2\$s\nTo cancel the recently inactive membership use this link:\n%4\$s";
+$L['aut_emailreg'] = "Hi %1\$s,\n\nTo use your account you need to activate it with this link:\n%2\$s\n\nTo cancel the recently inactive membership use this link:\n%3\$s";
 
 $L['aut_emailchange'] = "Hi %1\$s,\nTo change your recent email please use this activation link:\n%2\$s";
 
@@ -74,7 +74,7 @@ $L['pro_wrongpass'] = 'You didn\'t enter your present password, or it\'s wrong';
 $L['pro_invalidbirthdate'] = 'The birthdate is invalid.';
 
 $L['useed_accountactivated'] = 'Account activated';
-$L['useed_email'] = 'You are receiving this email because an administrator activated your account. You may now login using the username and password you received in a previous email.';
+$L['useed_email'] = 'You are receiving this email because an administrator activated your account. You may now login.';
 $L['useed_subtitle'] = '&nbsp;';
 $L['useed_title'] = 'Edit';
 

--- a/modules/users/inc/users.functions.php
+++ b/modules/users/inc/users.functions.php
@@ -76,6 +76,7 @@ function cot_add_user($ruser, $email = null, $name = null, $password = null, $ma
 	$ruser['user_regdate'] = (int)$sys['now'];
 	$ruser['user_logcount'] = 0;
 	$ruser['user_lastip'] = empty($ruser['user_lastip']) ? $usr['ip'] : $ruser['user_lastip'];
+	$ruser['user_token'] = cot_unique(16);
 
 	if (!$db->insert($db_users, $ruser)) return;
 
@@ -96,7 +97,7 @@ function cot_add_user($ruser, $email = null, $name = null, $password = null, $ma
 		if ($cfg['users']['regrequireadmin'])
 		{
 			$subject = $L['aut_regrequesttitle'];
-			$body = sprintf($L['aut_regrequest'], $ruser['user_name'], $password);
+			$body = sprintf($L['aut_regrequest'], $ruser['user_name']);
 			$body .= "\n\n".$L['aut_contactadmin'];
 			cot_mail($ruser['user_email'], $subject, $body);
 
@@ -108,9 +109,9 @@ function cot_add_user($ruser, $email = null, $name = null, $password = null, $ma
 		else
 		{
 			$subject = $L['Registration'];
-			$activate = $cfg['mainurl'].'/'.cot_url('users', 'm=register&a=validate&v='.$ruser['user_lostpass'].'&y=1', '', true);
-			$deactivate = $cfg['mainurl'].'/'.cot_url('users', 'm=register&a=validate&v='.$ruser['user_lostpass'].'&y=0', '', true);
-			$body = sprintf($L['aut_emailreg'], $ruser['user_name'], $password, $activate, $deactivate);
+			$activate = $cfg['mainurl'].'/'.cot_url('users', 'm=register&a=validate&token='.$ruser['user_token'].'&v='.$ruser['user_lostpass'].'&y=1', '', true);
+			$deactivate = $cfg['mainurl'].'/'.cot_url('users', 'm=register&a=validate&token='.$ruser['user_token'].'&v='.$ruser['user_lostpass'].'&y=0', '', true);
+			$body = sprintf($L['aut_emailreg'], $ruser['user_name'], $activate, $deactivate);
 			$body .= "\n\n".$L['aut_contactadmin'];
 			cot_mail($ruser['user_email'], $subject, $body);
 		}

--- a/modules/users/inc/users.register.php
+++ b/modules/users/inc/users.register.php
@@ -16,6 +16,7 @@ require_once cot_incfile('auth');
 
 $v = cot_import('v','G','ALP');
 $y = cot_import('y','G','INT');
+$token = cot_import('token', 'G', 'ALP');
 
 list($usr['auth_read'], $usr['auth_write'], $usr['isadmin']) = cot_auth('users', 'a');
 
@@ -143,9 +144,15 @@ elseif ($a == 'validate' && mb_strlen($v) == 32)
 					include $pl;
 				}
 				/* ===== */
-
 				cot_auth_clear($row['user_id']);
-				cot_redirect(cot_url('message', 'msg=106', '', true));
+				if(!empty($token) && $token==$row['user_token'] && $sys['now']<($row['user_regdate']+172800))
+				{
+					cot_redirect(cot_url('login', 'a=check&v='.$v.'&token='.$token, '', true));
+				}
+				else
+				{
+					cot_redirect(cot_url('message', 'msg=106', '', true));
+				}
 			}
 			elseif ($y == 0)
 			{


### PR DESCRIPTION
If a user clicks the user activation link, the user will be automatically logged in without a message saying anything. Do you think there should be a message indicating that the account is active and that they are being logged in ?

The following check takes place before logging the user in: The user must match 32 and 16 character alphanumeric  strings (user_lostpass and user_token) that they receive in the activation email, must be in main group "4" ( they meet this requirement when they match user_lostpass and user_token since their account is technically activated but not logged into yet), and can't have a registration date older than 2 days. If the user fails everything but the lostpass, then they can still activate like normal but must log in manually. This allows this to be backwards compatible if a user had received an e-mail with an activation link before this change and/or if the activation is older than 2 days.

If this gets accepted, other language files must be updated.
