### PR TITLE
Suggest to remove protocol in copyright link

### DIFF
--- a/system/common.php
+++ b/system/common.php
@@ -588,7 +588,7 @@ else
 	require_once './images/icons/' . $cfg['defaulticons'] . '/resources.php';
 }
 
-$out['copyright'] = "<a href=\"http://www.cotonti.com\">".$L['foo_poweredby']." Cotonti</a>";
+$out['copyright'] = "<a href=\"//www.cotonti.com\" target=\"_blank\">".$L['foo_poweredby']." Cotonti</a>";
 
 /* ======== Various ======== */
 

--- a/system/common.php
+++ b/system/common.php
@@ -588,7 +588,7 @@ else
 	require_once './images/icons/' . $cfg['defaulticons'] . '/resources.php';
 }
 
-$out['copyright'] = "<a href=\"//www.cotonti.com\" target=\"_blank\">".$L['foo_poweredby']." Cotonti</a>";
+$out['copyright'] = "<a href=\"https://www.cotonti.com\" target=\"_blank\">".$L['foo_poweredby']." Cotonti</a>";
 
 /* ======== Various ======== */
 


### PR DESCRIPTION
I suggest to remove http protocol in copyright, for example on sites using SSL, there should not be links to http protocol. The protocol can be omitted, browsers and search engines are all well aware, so for external links simply //. Also propose to add Target attribute to open a new browser window.
Google about "Links to Your Site": ( https://support.google.com/webmasters/answer/55281 )