### PR TITLE
Add new hook for override RSS tags

### DIFF
--- a/modules/rss/rss.php
+++ b/modules/rss/rss.php
@@ -267,6 +267,14 @@ if (count($items) > 0)
 			'RSS_ROW_LINK' => $item['link'],
 			'RSS_ROW_FIELDS' => $item['fields']
 		));
+                
+          /* === Hook === */
+          foreach (cot_getextplugins('rss.items_row') as $pl)
+          {
+               include $pl;
+          }
+          /* ===== */ 
+                          
 		$t->parse('MAIN.ITEM_ROW');
 	}
 }

--- a/modules/rss/rss.php
+++ b/modules/rss/rss.php
@@ -269,7 +269,7 @@ if (count($items) > 0)
 		));
                 
           /* === Hook === */
-          foreach (cot_getextplugins('rss.items_row') as $pl)
+          foreach (cot_getextplugins('rss.item.loop') as $pl)
           {
                include $pl;
           }


### PR DESCRIPTION
I propose to add a hook rss.items_row to be able to override its
function or process tags RSS