### PR TITLE
Add new hook for override RSS tags

### DIFF
--- a/modules/rss/rss.php
+++ b/modules/rss/rss.php
@@ -256,6 +256,9 @@ $t->assign(array(
 	'RSS_DATE' => cot_fix_pubdate(date("r", $rssNow))
 ));
 
+/* === Hook - Part1 : Set === */
+$extp = cot_getextplugins('rss.item.loop');
+/* ===== */
 if (count($items) > 0)
 {
 	foreach ($items as $item)
@@ -267,7 +270,15 @@ if (count($items) > 0)
 			'RSS_ROW_LINK' => $item['link'],
 			'RSS_ROW_FIELDS' => $item['fields']
 		));
-		$t->parse('MAIN.ITEM_ROW');
+        
+	/* === Hook - Part2 : Include === */
+	foreach ($extp as $pl)
+	{
+		include $pl;
+	}
+	/* ===== */
+           
+	$t->parse('MAIN.ITEM_ROW');
 	}
 }
 


### PR DESCRIPTION
Add a hook rss.item.loop to be able to override its
function or process tags RSS.