### PR TITLE
Fix #1611:Duplicate path links

### DIFF
--- a/modules/page/inc/page.list.php
+++ b/modules/page/inc/page.list.php
@@ -208,6 +208,9 @@ if (!empty($cfg['page']['cat_' . $c]['metatitle']))
 }
 // Building the canonical URL
 $out['canonical_uri'] = cot_url('page', $pageurl_params);
+if ($out['uri'] != $out['canonical_uri']) {
+    cot_die_message(404, true);
+}
 
 $_SESSION['cat'] = $c;
 

--- a/modules/page/inc/page.main.php
+++ b/modules/page/inc/page.main.php
@@ -131,6 +131,9 @@ if ($pg > 0)
 	$pageurl_params['pg'] = $pg;
 }
 $out['canonical_uri'] = cot_url('page', $pageurl_params);
+if ($out['uri'] != $out['canonical_uri']) {
+    cot_die_message(404, true);
+}
 
 $mskin = cot_tplfile(array('page', $cat['tpl']));
 


### PR DESCRIPTION
This fix eliminates duplicate page on multiple URLs. When attempting to access a non-canonical URL, 404 will be issued.