### PR TITLE
#1830 Update install.functions.php

### DIFF
--- a/modules/install/inc/install.functions.php
+++ b/modules/install/inc/install.functions.php
@@ -136,11 +136,12 @@ function cot_installParseExtensions($ext_type, $default_list = [], $selected_lis
                 $plugins_list = empty($info['Requires_plugins'])
                     ? $L['None']
                     : implode(', ', explode(',', $info['Requires_plugins']));
-
+                    
                 $requires = cot_rc('install_code_requires', [
-                    'modules_list' => $modules_list,
-                    'plugins_list' => $plugins_list
-                ]);
+                        'modules_list' => $modules_list,
+                        'plugins_list' => $plugins_list,
+                    ]);
+
             } else {
                 $requires = '';
             }
@@ -182,22 +183,21 @@ function cot_installParseExtensions($ext_type, $default_list = [], $selected_lis
                 "{$ext_type_uc}_ROW_RECOMMENDS" => $recommends,
             ]);
 
-            // Parse each extension row
+            // Render each extension row
             $t->parse("MAIN.STEP_4.$block_name");
         }
     }
     if ($ext_type_lc == 'plugin' && $prev_cat != '') {
-        // Parse the last category
+        // Render the last category
         $t->parse("MAIN.STEP_4.{$ext_type_uc}_CAT");
     }
 }
 
 /**
  * Sorts selected extensions based on their 'Order' property if provided.
- *
  * @param array $selected_extensions List of extension names (unsorted)
- * @param bool  $is_module           TRUE for modules, FALSE for plugins
- * @return array                     Sorted list of extension names
+ * @param bool $is_module TRUE for modules, FALSE for plugins
+ * @return array Sorted list of extension names
  */
 function cot_installSortExtensions($selected_extensions, $is_module = false)
 {

--- a/modules/install/inc/install.functions.php
+++ b/modules/install/inc/install.functions.php
@@ -16,7 +16,7 @@ use cot\extensions\ExtensionsHelper;
  */
 function cot_installProcessFile()
 {
-    $processFileDir =  isset(Cot::$cfg['cache_dir']) ? Cot::$cfg['cache_dir'] : './datas/cache';
+    $processFileDir = isset(Cot::$cfg['cache_dir']) ? Cot::$cfg['cache_dir'] : './datas/cache';
     return $processFileDir . '/install';
 }
 
@@ -57,26 +57,32 @@ function cot_get_config($file)
 /**
  * Replaces a sample config with its actual value
  *
- * @param string $file_contents Config file contents
- * @param string $config_name Config option name
- * @param string $config_value Config value to set
- * @return string Modified file contents
+ * @param string $file_contents Config file contents (by reference)
+ * @param string $config_name   Config option name, e.g. 'mysqlpassword'
+ * @param string $config_value  Actual value to set, e.g. user-supplied password
+ * @return void
  */
 function cot_installConfigReplace(&$file_contents, $config_name, $config_value)
 {
-    $file_contents = preg_replace("#^\\\$cfg\['$config_name'\]\s*=\s*'.*?';#m",
-        "\$cfg['$config_name'] = '$config_value';", $file_contents);
+    // Burada özel karakterleri kaçışlıyoruz:
+    $config_value_escaped = str_replace(
+        ['\\', '$', "'"],
+        ['\\\\', '\\$', "\\'"],
+        $config_value
+    );
+
+    $pattern = "#^\\\$cfg\\['$config_name'\\]\\s*=\\s*'.*?';#m";
+    $replacement = "\$cfg['$config_name'] = '$config_value_escaped';";
+
+    $file_contents = preg_replace($pattern, $replacement, $file_contents);
 }
 
 /**
  * Parses extensions selection section
  *
- * @param string $ext_type Extension type: 'Module' or 'Plugin'
- * @param array $default_list A list of recommended extensions (checked by default)
- * @param array $selected_list A list of previously selected extensions
- *
- * @todo use ExtensionsDictionary::TYPE_XXX constants as extension type
- *
+ * @param string $ext_type      'Module' veya 'Plugin'
+ * @param array  $default_list  Tavsiye edilen eklentiler (varsayılan işaretli)
+ * @param array  $selected_list Kullanıcı tarafından seçili eklentiler
  */
 function cot_installParseExtensions($ext_type, $default_list = [], $selected_list = [])
 {
@@ -89,7 +95,9 @@ function cot_installParseExtensions($ext_type, $default_list = [], $selected_lis
     $ext_type_lc == 'plugin' ? uasort($ext_list, 'cot_extension_catcmp') : ksort($ext_list);
 
     $prev_cat = '';
-    $block_name = $ext_type_lc == 'plugin' ? "{$ext_type_uc}_CAT.{$ext_type_uc}_ROW" : "{$ext_type_uc}_ROW";
+    $block_name = $ext_type_lc == 'plugin' 
+        ? "{$ext_type_uc}_CAT.{$ext_type_uc}_ROW"
+        : "{$ext_type_uc}_ROW";
 
     $extensionHelper = ExtensionsHelper::getInstance();
 
@@ -98,46 +106,65 @@ function cot_installParseExtensions($ext_type, $default_list = [], $selected_lis
             $code = $f;
             if ($ext_type_lc == 'plugin' && $prev_cat != $info['Category']) {
                 if ($prev_cat != '') {
-                    // Render previous category
+                    // Önceki kategoriyi çıkartalım
                     $t->parse("MAIN.STEP_4.{$ext_type_uc}_CAT");
                 }
-                // Assign a new one
+                // Yeni kategori
                 $prev_cat = $info['Category'];
-                $catTitle = !empty($L['ext_cat_' . $info['Category']]) ?
-                    $L['ext_cat_' . $info['Category']] : $info['Category'];
+                $catTitle = !empty($L['ext_cat_' . $info['Category']])
+                    ? $L['ext_cat_' . $info['Category']]
+                    : $info['Category'];
 
                 $t->assign('PLUGIN_CAT_TITLE', $catTitle);
             }
 
+            // Requires
             if (!empty($info['Requires_modules']) || !empty($info['Requires_plugins'])) {
-                $modules_list = empty($info['Requires_modules']) ? $L['None']
+                $modules_list = empty($info['Requires_modules'])
+                    ? $L['None']
                     : implode(', ', explode(',', $info['Requires_modules']));
-                $plugins_list = empty($info['Requires_plugins']) ? $L['None']
+
+                $plugins_list = empty($info['Requires_plugins'])
+                    ? $L['None']
                     : implode(', ', explode(',', $info['Requires_plugins']));
-                $requires = cot_rc('install_code_requires',
-                    array('modules_list' => $modules_list, 'plugins_list' => $plugins_list));
+
+                $requires = cot_rc('install_code_requires', [
+                    'modules_list' => $modules_list,
+                    'plugins_list' => $plugins_list
+                ]);
             } else {
                 $requires = '';
             }
 
+            // Recommends
             if (!empty($info['Recommends_modules']) || !empty($info['Recommends_plugins'])) {
-                $modules_list = empty($info['Recommends_modules']) ? $L['None']
+                $modules_list = empty($info['Recommends_modules'])
+                    ? $L['None']
                     : implode(', ', explode(',', $info['Recommends_modules']));
-                $plugins_list = empty($info['Recommends_plugins']) ? $L['None']
+
+                $plugins_list = empty($info['Recommends_plugins'])
+                    ? $L['None']
                     : implode(', ', explode(',', $info['Recommends_plugins']));
-                $recommends = cot_rc('install_code_recommends',
-                    array('modules_list' => $modules_list, 'plugins_list' => $plugins_list));
+
+                $recommends = cot_rc('install_code_recommends', [
+                    'modules_list' => $modules_list,
+                    'plugins_list' => $plugins_list
+                ]);
             } else {
                 $recommends = '';
             }
 
+            // Hangi eklentiler varsayılan seçili veya kullanıcı seçimi
             if ((is_array($selected_list) && count($selected_list)) > 0) {
                 $checked = in_array($code, $selected_list);
             } else {
                 $checked = in_array($code, $default_list);
             }
 
-            $extensionType = $ext_type === 'Module' ? ExtensionsDictionary::TYPE_MODULE : ExtensionsDictionary::TYPE_PLUGIN;
+            $extensionType = $ext_type === 'Module'
+                ? ExtensionsDictionary::TYPE_MODULE
+                : ExtensionsDictionary::TYPE_PLUGIN;
+
             $t->assign([
                 "{$ext_type_uc}_ROW_CHECKBOX" => cot_checkbox($checked, "install_{$ext_type_lc}s[$code]"),
                 "{$ext_type_uc}_ROW_TITLE" => $extensionHelper->getTitle($code, $extensionType),
@@ -145,11 +172,13 @@ function cot_installParseExtensions($ext_type, $default_list = [], $selected_lis
                 "{$ext_type_uc}_ROW_REQUIRES" => $requires,
                 "{$ext_type_uc}_ROW_RECOMMENDS" => $recommends,
             ]);
+
+            // Parse et
             $t->parse("MAIN.STEP_4.$block_name");
         }
     }
     if ($ext_type_lc == 'plugin' && $prev_cat != '') {
-        // Render last category
+        // Son kategoriyi parse et
         $t->parse("MAIN.STEP_4.{$ext_type_uc}_CAT");
     }
 }
@@ -157,29 +186,30 @@ function cot_installParseExtensions($ext_type, $default_list = [], $selected_lis
 /**
  * Sorts selected extensions by their setup order if present
  *
- * @global array $cfg
- * @param array $selected_extensions Unsorted list of extension names
- * @param bool $is_module TRUE if sorting modules, FALSE if sorting plugins
- * @return array Sorted list of extension names
+ * @param array $selected_extensions Eklenti isimleri (sıralanmamış)
+ * @param bool  $is_module TRUE ise modüller, FALSE ise eklentiler
+ * @return array Sıralı liste
  */
-function cot_installSortExtensions($selected_extensions, $is_module = FALSE)
+function cot_installSortExtensions($selected_extensions, $is_module = false)
 {
     global $cfg;
     $path = $is_module ? $cfg['modules_dir'] : $cfg['plugins_dir'];
-    $ret = array();
+    $ret = [];
 
-    // Split into groups by Order value
-    $extensions = array();
+    // Order değerine göre gruplara ayır
+    $extensions = [];
     foreach ($selected_extensions as $name) {
         $info = cot_infoget("$path/$name/$name.setup.php", 'COT_EXT');
         $order = isset($info['Order']) ? (int) $info['Order'] : COT_PLUGIN_DEFAULT_ORDER;
+
+        // Kategori 'post-install' ise ve order < 999 ise 999 yap
         if (isset($info['Category']) && $info['Category'] == 'post-install' && $order < 999) {
             $order = 999;
         }
         $extensions[$order][] = $name;
     }
 
-    // Merge back into a single array
+    // Grupları sırayla yeniden birleştir
     foreach ($extensions as $grp) {
         foreach ($grp as $name) {
             $ret[] = $name;


### PR DESCRIPTION
Bug fix; @Dayver 
If mysql password contains character sequence

'....@$3....'

then in datas/config.php after stage 2 install proces remains only

$cfg['mysqlpassword'] = '....@....';

When installer test connect with password and passes inspection but when his write to config.php pass loos character sequence and on next stage instaler have error connect to db. PHP 8.1

/*----------------------*/
We fixed an issue in the installer where MySQL passwords containing sequences like `@$3` were truncated in `datas/config.php`. The problem was that `$` was interpreted as a regex backreference when using `preg_replace`. To resolve this, we updated the `cot_installConfigReplace()` function in `install.functions.php` to escape special characters (e.g., `$`, `\`) before inserting them into the replacement string, ensuring the password is written correctly without losing any characters.


I used the following information to test the solution to the problem;
Cotonti Siena v0.9.25 
Php:8.1
Password:'....@$3....''é!'