### PR TITLE
Update page.trashcan.php

### DIFF
--- a/modules/page/page.trashcan.php
+++ b/modules/page/page.trashcan.php
@@ -27,6 +27,17 @@ $trash_types['page'] = Cot::$db->pages;
  */
 function cot_trash_page_sync($data)
 {
+    // Check if alias exists
+    $page_count = Cot::$db->query(
+        'SELECT COUNT(*) FROM ' . Cot::$db->pages . ' WHERE page_alias = ? AND page_id != ?',
+        [$data['page_alias'], $data['page_id']]
+    )->fetchColumn();
+    
+    if ($page_count > 0) {
+        // If alias exists, generate a new one
+        $data['page_alias'] = $data['page_alias'] . '_restored_' . $data['page_id'];
+    }
+
     cot_page_updateStructureCounters($data['page_cat']);
     if (\Cot::$cache) {
         if (\Cot::$cfg['cache_page']) {


### PR DESCRIPTION
When the page is deleted, the alias will be made unique by adding _deleted_[page_id] at the end. When the page is restored, if there is another page with the same alias, it will be made unique by adding _restored_[page_id] to the end of the alias. In this way:
Pages with the same alias can be in different categories Aliases of deleted and restored pages will not overlap Category code will be mandatory in URLs
This solution will both avoid alias conflicts and allow pages with the same alias in different categories.

Bug Fix #1788