### PR TITLE
Update trashcan.page.delete.php

### DIFF
--- a/plugins/trashcan/trashcan.page.delete.php
+++ b/plugins/trashcan/trashcan.page.delete.php
@@ -54,6 +54,7 @@ if (!Cot::$cfg['forcedefaultlang'] && Cot::$cfg['defaultlang'] !== $lang) {
 $trashcan = TrashcanService::getInstance();
 
 // Add page to trash
+$pageData['page_alias'] = $pageData['page_alias'] . '_deleted_' . $id;
 $trashcanId = $trashcan->put(
     PageDictionary::SOURCE_PAGE,
     Cot::$L['Page'] . " #" . $id . " " . $pageData['page_title'],


### PR DESCRIPTION
When the page is deleted, the alias will be made unique by adding _deleted_[page_id] at the end. When the page is restored, if there is another page with the same alias, it will be made unique by adding _restored_[page_id] to the end of the alias. In this way:
Pages with the same alias can be in different categories Aliases of deleted and restored pages will not overlap Category code will be mandatory in URLs
This solution will both avoid alias conflicts and allow pages with the same alias in different categories.

Bug Fix #1788