### PR TITLE
Update resources.rc.php

### DIFF
--- a/system/resources.rc.php
+++ b/system/resources.rc.php
@@ -30,10 +30,10 @@ $R['input_radio_separator'] = ' ';
 $R['input_select'] = '<select name="{$name}"{$attrs}>{$options}</select>{$error}';
 $R['input_submit'] = '<button type="submit" name="{$name}" {$attrs}>{$value}</button>';
 $R['input_text'] = '<input type="text" name="{$name}" value="{$value}" {$attrs} />{$error}';
-$R['input_textarea'] = '<textarea name="{$name}" rows="{$rows}" cols="{$cols}" {$attrs}>{$value}</textarea>{$error}';
-$R['input_textarea_editor'] =  '<textarea class="editor" name="{$name}" rows="{$rows}" cols="{$cols}"{$attrs}>{$value}</textarea>{$error}';
-$R['input_textarea_medieditor'] =  '<textarea class="medieditor" name="{$name}" rows="{$rows}" cols="{$cols}"{$attrs}>{$value}</textarea>{$error}';
-$R['input_textarea_minieditor'] =  '<textarea class="minieditor" name="{$name}" rows="{$rows}" cols="{$cols}"{$attrs}>{$value}</textarea>{$error}';
+$R['input_textarea'] = '<textarea name="{$name}"' . (!empty($rows) ? ' rows="{$rows}"' : '') . (!empty($cols) ? ' cols="{$cols}"' : '') . ' {$attrs}>{$value}</textarea>{$error}';
+$R['input_textarea_editor'] =  '<textarea class="editor" name="{$name}"' . (!empty($rows) ? ' rows="{$rows}"' : '') . (!empty($cols) ? ' cols="{$cols}"' : '') . '{$attrs}>{$value}</textarea>{$error}';
+$R['input_textarea_medieditor'] =  '<textarea class="medieditor" name="{$name}"' . (!empty($rows) ? ' rows="{$rows}"' : '') . (!empty($cols) ? ' cols="{$cols}"' : '') . '{$attrs}>{$value}</textarea>{$error}';
+$R['input_textarea_minieditor'] =  '<textarea class="minieditor" name="{$name}"' . (!empty($rows) ? ' rows="{$rows}"' : '') . (!empty($cols) ? ' cols="{$cols}"' : '') . '{$attrs}>{$value}</textarea>{$error}';
 $R['input_filebox'] = '<a href="{$filepath}">{$value}</a><br /><input type="file" name="{$name}" {$attrs} /><br /><label><input type="checkbox" name="{$delname}" value="1" /> '.$L['Delete'].'</label>{$error}';
 $R['input_filebox_empty'] = '<input type="file" name="{$name}" {$attrs} />{$error}';
 


### PR DESCRIPTION
1. Textarea element's rows and cols properties will now be rendered only when their values are specified.
2. These properties will not be rendered for empty or null values This change will apply to both regular textarea and textarea with editor classes.
3. This way, when rows and cols properties are not specified, the HTML output will not contain empty properties and the HTML validation problem will be solved.

Fixed #1789