### PR TITLE
Update page.setup.php

### DIFF
--- a/modules/page/page.setup.php
+++ b/modules/page/page.setup.php
@@ -22,6 +22,7 @@ count_admin=03:radio::0:
 autovalidate=04:radio::1:
 maxlistsperpage=06:select:5,10,15,20,25,30,40,50,60,70,100,200,500:30:
 title_page=07:string::{TITLE} - {CATEGORY}:
+list_cache_enabled=08:radio::1:Enable page list caching
 [END_COT_EXT_CONFIG]
 
 [BEGIN_COT_EXT_CONFIG_STRUCTURE]
@@ -35,3 +36,6 @@ metatitle=07:string:::
 metadesc=08:string:::
 [END_COT_EXT_CONFIG_STRUCTURE]
 ==================== */
+
+// Cache settings
+$cfg['page']['list_cache_enabled'] = true;


### PR DESCRIPTION
With this change
We added a new configuration option called list_cache_enabled We used a radio (yes/no) option as the type
We set 1 (active) as default value
We added “Enable page list caching” as a description Now administrators:
Go to the settings of the “Page” module from the admin panel Turning “Enable page list caching” on and off
They can specify whether or not to use cache in their page list

@seditio fixed #1820 