### PR TITLE
Update page.functions.php

### DIFF
--- a/modules/page/inc/page.functions.php
+++ b/modules/page/inc/page.functions.php
@@ -838,13 +838,20 @@ function cot_page_enum(
     $template = '',
     $order = '',
     $condition = '',
-	$active_only = true,
+    $active_only = true,
     $use_subcat = true,
     $exclude_current = false,
     $blacklist = '',
     $pagination = '',
     $cache_ttl = null
 ) {
+    global $pageListCacheEnabled;
+    
+    // Cache control
+    if (isset($pageListCacheEnabled) && !$pageListCacheEnabled) {
+        $cache_ttl = 0;
+    }
+    
     // $L, $Ls, $R are needed for hook includes
     global $L, $Ls, $R;
 
@@ -1049,4 +1056,3 @@ function cot_page_enum(
 	}
 	return $page_query_html;
 }
-


### PR DESCRIPTION
With this change
We added a new configuration option called list_cache_enabled We used a radio (yes/no) option as the type
We set 1 (active) as default value
We added “Enable page list caching” as a description Now administrators:
Go to the settings of the “Page” module from the admin panel Turning “Enable page list caching” on and off
They can specify whether or not to use cache in their page list

@seditio  fixed #1820 