### PR TITLE
Update page.list.php

### DIFF
--- a/modules/page/inc/page.list.php
+++ b/modules/page/inc/page.list.php
@@ -15,6 +15,9 @@ defined('COT_CODE') or die('Wrong URL');
 const COT_LIST = true;
 Cot::$env['location'] = 'list';
 
+// Cache control
+$pageListCacheEnabled = (bool)Cot::$cfg['page']['list_cache_enabled'];
+
 $s = cot_import('s', 'G', 'ALP'); // order field name without 'page_'
 $w = cot_import('w', 'G', 'ALP', 4); // order way (asc, desc)
 $c = cot_import('c', 'G', 'TXT'); // cat code


### PR DESCRIPTION
With this change
We added a new configuration option called list_cache_enabled We used a radio (yes/no) option as the type
We set 1 (active) as default value
We added “Enable page list caching” as a description Now administrators:
Go to the settings of the “Page” module from the admin panel Turning “Enable page list caching” on and off
They can specify whether or not to use cache in their page list

@seditio  fixed #1820