### PR TITLE
Update search.php

### DIFF
--- a/plugins/search/search.php
+++ b/plugins/search/search.php
@@ -375,7 +375,14 @@ if (!empty($sq)) {
             }
         }
 
-		if (!Cot::$db->fieldExists(Cot::$db->pages, 'page_' . $rs['pagsort'])) {
+		// Allowed sort fields
+		$allowedSortFields = ['date', 'title', 'count', 'cat'];
+		if (!empty(Cot::$cfg['plugin']['search']['allowed_sort_fields'])) {
+			$extra = explode(',', Cot::$cfg['plugin']['search']['allowed_sort_fields']);
+			$allowedSortFields = array_merge($allowedSortFields, array_map('trim', $extra));
+		}
+
+		if (!in_array($rs['pagsort'], $allowedSortFields)) {
 			$rs['pagsort'] = 'date';
 		}
 


### PR DESCRIPTION
Search: Restrict sorting to allowed fields only (fix #1823)

- Search results can now only be sorted by publication date, title, views, or category.
- Additional allowed sort fields can be set in the plugin config as 'allowed_sort_fields'.
- Any attempt to sort by a non-allowed field will default to 'date'.