### PR TITLE
Create functions.custom.php

### DIFF
--- a/system/functions.custom.php
+++ b/system/functions.custom.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Custom Functions for Cotonti
+ *
+ * @package Cotonti
+ * @copyright (c) Cotonti Team
+ * @license https://github.com/Cotonti/Cotonti/blob/master/License.txt
+ */
+
+defined('COT_CODE') or die('Wrong URL');
+
+/**
+ * Generates a unique cache path based on the URL to fix the conflict between URLeditor and page cache
+ * 
+ * @param array $parsedUrl Parsed URL components
+ * @return string Unique cache path
+ */
+function cot_staticCacheGetPathByUri($parsedUrl)
+{
+    $get = [];
+    if (!empty($parsedUrl['query'])) {
+        $parsedUrl['query'] = str_replace('&amp;', '&', $parsedUrl['query']);
+        parse_str($parsedUrl['query'], $get);
+    }
+    
+    // Start with base path
+    $path = '';
+    
+    // Add the host to make cache keys unique per domain/subdomain
+    if (!empty($parsedUrl['host'])) {
+        $path = preg_replace('#\W#', '_', $parsedUrl['host']) . '_';
+    }
+    
+    // Add module (e parameter)
+    if (!empty($get['e'])) {
+        $path .= preg_replace('#\W#', '', $get['e']);
+    } elseif ($parsedUrl['path'] !== '/') {
+        // If no e parameter, use the URL path
+        $parsedUrl['path'] = rawurldecode($parsedUrl['path']);
+        $path .= trim(preg_replace('#\W#', '_', trim($parsedUrl['path'], '/')), '_');
+    }
+    
+    // Add category (c parameter) if exists
+    if (!empty($path)) {
+        $c = isset($get['c']) ? trim($get['c']) : null;
+        if (!empty($c)) {
+            $path .= '/' . $c;
+        }
+    }
+    
+    // If nothing found, use 'index'
+    if (empty($path)) {
+        $path = 'index';
+    }
+    
+    return $path;
+} 


### PR DESCRIPTION
Problem #1035  solved.

Cause of the issue: Conflict between URLeditor and page cache during URL processing.  For two different subdomains (for example site.com/cat and A.site.com/cat), the caching system  was creating the same cache file for both.

Solution: The cot_staticCacheGetPathByUri() function was created in system/functions.custom.php. This function takes into account the subdomains and other parameters in the URLs.  unique cache paths.

The system is designed to check for the existence of this function and use it if it exists. This way, different cache paths are created for different URLs converted by URLeditor.  files are created and the conflict problem is solved.

Technical details:
- The getPathByUri method of the Cache class is used to create the cot_staticCacheGetPathByUri() function.  and, if present, uses it to create a cache path from the URL.
- The generated custom function takes the host address (including subdomain) and other parameters from the URL.  to create a unique cache path for each URL.
- In particular, URLs like site.com/cat and A.site.com/cat now have different cache keys so the conflict problem is solved.
@esclkm @Alex300 @trustmaster 