### PR TITLE
Update admin.en.lang.php

### DIFF
--- a/lang/en/admin.en.lang.php
+++ b/lang/en/admin.en.lang.php
@@ -329,6 +329,8 @@ $L['adm_tpl_code'] = 'Custom category or template code';
 $L['adm_tpl_resyncalltitle'] = 'Resync all page counters';
 $L['adm_tpl_resynctitle'] = 'Resync category page counters';
 $L['adm_help_structure'] = 'The pages that belong to the category &quot;system&quot; are not displayed in the public listings, it\'s to make standalone pages.';
+$L['adm_structure_alias_conflict'] = 'The category code conflicts with an existing page alias';
+$L['adm_structure_help1'] = '';
 
 /**
  * Structure Section


### PR DESCRIPTION
Solution: #1781 Autoalias - Page Alias and Category Code Conflict The problem
404 error occurs when page alias “abc” conflicts with category code “abc” URL parser doesn't know which one to show
Solution
Added control during automatic alias creation:
Automatic ID is added if there is a conflict with category codes This creates the unique alias “123-abc” instead of “abc” Added control during category creation:
If there is an alias with the same name, a warning is given and the process is blocked Two-way control prevents both current and future conflicts. SEO-friendly URLs will now work seamlessly.