### PR TITLE
Update autoalias2.functions.php

### DIFF
--- a/plugins/autoalias2/inc/autoalias2.functions.php
+++ b/plugins/autoalias2/inc/autoalias2.functions.php
@@ -17,9 +17,10 @@ require_once cot_incfile('page', 'module');
  * @param string $title Title
  * @param int $id Page ID
  * @param bool $duplicate TRUE if duplicate alias was previously detected
+ * @param bool $categoryConflict TRUE if category code conflict was detected 
  * @return string
  */
-function autoalias2_convert($title, $id = 0, $duplicate = false)
+function autoalias2_convert($title, $id = 0, $duplicate = false, $categoryConflict = false)
 {
 	global $cfg, $cot_translit, $cot_translit_custom;
 
@@ -43,7 +44,10 @@ function autoalias2_convert($title, $id = 0, $duplicate = false)
 		$title = mb_strtolower($title);
 	}
 
-	if ($cfg['plugin']['autoalias2']['prepend_id'] && !empty($id))
+	// Always prepend ID if:
+	// 1. Plugin config set to do so
+	// 2. Or if there's a category conflict and we need to avoid it
+	if (($cfg['plugin']['autoalias2']['prepend_id'] && !empty($id)) || ($categoryConflict && !empty($id)))
 	{
 		$title = $id . $cfg['plugin']['autoalias2']['sep'] . $title;
 	}
@@ -71,17 +75,44 @@ function autoalias2_convert($title, $id = 0, $duplicate = false)
  *
  * @param string $title Page title
  * @param int $id Page ID
+ * @return string Generated alias
  */
 function autoalias2_update($title, $id)
 {
-	global $cfg, $db, $db_pages;
+	global $cfg, $db, $db_pages, $structure;
 	$duplicate = false;
+	$categoryConflict = false;
+	
 	do
 	{
-		$alias = autoalias2_convert($title, $id, $duplicate);
+		// First, generate the alias without checking conflicts
+		$tempAlias = autoalias2_convert($title, $id, $duplicate, $categoryConflict);
+		
+		// Get the "raw" alias without ID prefix to check for category conflicts
+		$rawAlias = $tempAlias;
+		if ($cfg['plugin']['autoalias2']['prepend_id'] && !empty($id)) {
+			// If ID is already prepended, we don't need to check for category conflict
+			$categoryConflict = false;
+		} else {
+			// Check if this alias conflicts with any category code
+			$categoryConflict = false;
+			if (isset($structure['page']) && is_array($structure['page'])) {
+				foreach ($structure['page'] as $cat => $catData) {
+					if (strcasecmp($cat, $rawAlias) === 0) {
+						$categoryConflict = true;
+						break;
+					}
+				}
+			}
+		}
+		
+		// Generate the final alias, with category conflict handling if needed
+		$alias = autoalias2_convert($title, $id, $duplicate, $categoryConflict);
+		
+		// Check for duplicate aliases in pages
 		if (!$cfg['plugin']['autoalias2']['prepend_id']
 			&& $db->query("SELECT COUNT(*) FROM $db_pages
-				WHERE page_alias = '$alias' AND page_id != $id")->fetchColumn() > 0)
+				WHERE page_alias = " . $db->quote($alias) . " AND page_id != $id")->fetchColumn() > 0)
 		{
 			$duplicate = true;
 		}
@@ -91,6 +122,7 @@ function autoalias2_update($title, $id)
 			$duplicate = false;
 		}
 	}
-	while ($duplicate && !$cfg['plugin']['autoalias2']['prepend_id']);
+	while (($duplicate || $categoryConflict) && !$cfg['plugin']['autoalias2']['prepend_id']);
+	
 	return $alias;
 }


### PR DESCRIPTION
Solution: #1781 Autoalias - Page Alias and Category Code Conflict The problem
404 error occurs when page alias “abc” conflicts with category code “abc” URL parser doesn't know which one to show
Solution
Added control during automatic alias creation:
Automatic ID is added if there is a conflict with category codes This creates the unique alias “123-abc” instead of “abc” Added control during category creation:
If there is an alias with the same name, a warning is given and the process is blocked Two-way control prevents both current and future conflicts. SEO-friendly URLs will now work seamlessly.