### PR TITLE
Update autoalias2.functions.php

### DIFF
--- a/plugins/autoalias2/inc/autoalias2.functions.php
+++ b/plugins/autoalias2/inc/autoalias2.functions.php
@@ -6,23 +6,20 @@
  * @copyright (c) Cotonti Team
  * @license https://github.com/Cotonti/Cotonti/blob/master/License.txt
  */
-
 defined('COT_CODE') or die('Wrong URL');
-
 require_once cot_incfile('page', 'module');
-
 /**
  * Converts a title into an alias
  *
  * @param string $title Title
  * @param int $id Page ID
  * @param bool $duplicate TRUE if duplicate alias was previously detected
+ * @param bool $categoryConflict TRUE if category code conflict was detected 
  * @return string
  */
-function autoalias2_convert($title, $id = 0, $duplicate = false)
+function autoalias2_convert($title, $id = 0, $duplicate = false, $categoryConflict = false)
 {
 	global $cfg, $cot_translit, $cot_translit_custom;
-
 	if($cfg['plugin']['autoalias2']['translit'] && file_exists(cot_langfile('translit', 'core')))
 	{
 		include cot_langfile('translit', 'core');
@@ -37,13 +34,14 @@ function autoalias2_convert($title, $id = 0, $duplicate = false)
 	}
 	$title = preg_replace('#[^\p{L}0-9\-_ ]#u', '', $title);
 	$title = str_replace(' ', $cfg['plugin']['autoalias2']['sep'], $title);
-
 	if ($cfg['plugin']['autoalias2']['lowercase'])
 	{
 		$title = mb_strtolower($title);
 	}
-
-	if ($cfg['plugin']['autoalias2']['prepend_id'] && !empty($id))
+	// Always prepend ID if:
+	// 1. Plugin config set to do so
+	// 2. Or if there's a category conflict and we need to avoid it
+	if (($cfg['plugin']['autoalias2']['prepend_id'] && !empty($id)) || ($categoryConflict && !empty($id)))
 	{
 		$title = $id . $cfg['plugin']['autoalias2']['sep'] . $title;
 	}
@@ -62,26 +60,44 @@ function autoalias2_convert($title, $id = 0, $duplicate = false)
 				break;
 		}
 	}
-
 	return $title;
 }
-
 /**
  * Updates an alias for a specific page
  *
  * @param string $title Page title
  * @param int $id Page ID
+ * @return string Generated alias
  */
 function autoalias2_update($title, $id)
 {
-	global $cfg, $db, $db_pages;
+	global $cfg, $db, $db_pages, $structure;
 	$duplicate = false;
+	$categoryConflict = false;
+	
 	do
 	{
-		$alias = autoalias2_convert($title, $id, $duplicate);
+		// First, generate the alias without checking conflicts
+		$tempAlias = autoalias2_convert($title, $id, $duplicate, $categoryConflict);
+		
+		// Check if this alias conflicts with any category code
+		$categoryConflict = false;
+		if (!$cfg['plugin']['autoalias2']['prepend_id'] && isset($structure['page']) && is_array($structure['page'])) {
+			foreach ($structure['page'] as $cat => $catData) {
+				if (strcasecmp($cat, $tempAlias) === 0) {
+					$categoryConflict = true;
+					break;
+				}
+			}
+		}
+		
+		// Generate the final alias, with category conflict handling if needed
+		$alias = autoalias2_convert($title, $id, $duplicate, $categoryConflict);
+		
+		// Check for duplicate aliases in pages
 		if (!$cfg['plugin']['autoalias2']['prepend_id']
 			&& $db->query("SELECT COUNT(*) FROM $db_pages
-				WHERE page_alias = '$alias' AND page_id != $id")->fetchColumn() > 0)
+				WHERE page_alias = " . $db->quote($alias) . " AND page_id != $id")->fetchColumn() > 0)
 		{
 			$duplicate = true;
 		}
@@ -91,6 +107,7 @@ function autoalias2_update($title, $id)
 			$duplicate = false;
 		}
 	}
-	while ($duplicate && !$cfg['plugin']['autoalias2']['prepend_id']);
+	while (($duplicate || $categoryConflict) && !$cfg['plugin']['autoalias2']['prepend_id']);
+	
 	return $alias;
 }


### PR DESCRIPTION
Fix: #1781 Autoalias - Page Alias and Category Code Conflict

Problem:
- 404 error occurs when page alias "abc" conflicts with category code "abc"
- URL parser doesn't know which one to show

Solution:
- Added control during automatic alias creation
- Automatic ID is added if there is a conflict with category codes
- This creates the unique alias "123-abc" instead of "abc"
- SEO-friendly URLs will now work seamlessly for pages even when their alias matches a category code