### PR TITLE
Update tags.tpl

### DIFF
--- a/plugins/tags/tpl/tags.tpl
+++ b/plugins/tags/tpl/tags.tpl
@@ -29,9 +29,10 @@
     <!-- END: TAGS_CLOUD -->
     <!-- BEGIN: TAGS_RESULT -->
     <div class="block">
-        <h2 class="search">{TAGS_RESULT_TITLE}</h2>
+        <!-- BEGIN: PAGES -->
+        <h2 class="search">{PHP.L.tags_Found_in_pages}</h2>
         <ol>
-            <!-- BEGIN: TAGS_RESULT_ROW -->
+            <!-- BEGIN: ITEM -->
             <li class="marginbottom10">
                 <span class="strong"><a href="{TAGS_RESULT_ROW_URL}">{TAGS_RESULT_ROW_TITLE}</a></span><br/>
                 <span class="small">{PHP.L.Sections}: {TAGS_RESULT_ROW_PATH}<br/>
@@ -40,8 +41,24 @@
                 <p>{TAGS_RESULT_ROW_PREVIEW}</p>
                 <!-- ENDIF -->
             </li>
-            <!-- END: TAGS_RESULT_ROW -->
+            <!-- END: ITEM -->
         </ol>
+        <!-- END: PAGES -->
+        <!-- BEGIN: FORUMS -->
+        <h2 class="search">{PHP.L.tags_Found_in_forums}</h2>
+        <ol>
+            <!-- BEGIN: ITEM -->
+            <li class="marginbottom10">
+                <span class="strong"><a href="{TAGS_RESULT_ROW_URL}">{TAGS_RESULT_ROW_TITLE}</a></span><br/>
+                <span class="small">{PHP.L.Sections}: {TAGS_RESULT_ROW_PATH}<br/>
+						{PHP.L.Tags}: {TAGS_RESULT_ROW_TAGS}</span>
+                <!-- IF {TAGS_RESULT_ROW_PREVIEW} -->
+                <p>{TAGS_RESULT_ROW_PREVIEW}</p>
+                <!-- ENDIF -->
+            </li>
+            <!-- END: ITEM -->
+        </ol>
+        <!-- END: FORUMS -->
         <!-- BEGIN: TAGS_RESULT_NONE -->
         <div class="error">
             {PHP.L.Noitemsfound}


### PR DESCRIPTION
Tags plugin: Separate tag search loops for Pages & Forums (fixes #1843)

* tpl/tags.tpl
  - Replaced generic TAGS_RESULT_ROW with dedicated PAGES.ITEM and FORUMS.ITEM blocks, each with its own header for easier styling.

* tags.php
  - cot_tag_search_pages() and cot_tag_search_forums() now parse the new blocks; removed legacy generic parsing.
  - Total results now calculated with array_sum(), pagination adjusted.
  - Displays TAGS_RESULT_NONE when no matches.

This mirrors the structure used in search.php and lets designers style forum- and page-related tag results independently.